### PR TITLE
Fix responsiveness of the /@user/favorites page

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -27,6 +27,7 @@ body {
   background-position: top;
   background-repeat: no-repeat;
 }
+
 .page {
   margin-top: 2 * $spacer;
   margin-bottom: 2 * $spacer;
@@ -54,8 +55,4 @@ body {
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-}
-
-.user-info {
-  min-width: 800px;
 }


### PR DESCRIPTION
Trying to fix responsiveness of  the /@user/favorites page. Location of the account name seems to be off.

Move account name into center of the screen by removing .user-info css class that contains min-width option 